### PR TITLE
Improved performance of array.uniq

### DIFF
--- a/array.lua
+++ b/array.lua
@@ -186,10 +186,13 @@ array = {
     raises_error(array, obj, 'uniq')
 
     local output = {}
+    local seen = {}
 
     for i=1, #obj do
-      if array.index_of(output, obj[i]) == -1 then
-        table.insert(output, obj[i])
+      local value = obj[i]
+      if not seen[value] then
+        seen[value] = true
+        table.insert(output, value)
       end
     end
 


### PR DESCRIPTION
Instead of storing seen elements in an array with O(N) time, store them as table keys with O(1) time. This consistently improves performance over every Lua version and all array sizes. Especially efficient with large arrays.